### PR TITLE
Add shared types with thematic terminology

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,14 +1,22 @@
-export type ConnectionStatus =
-  | 'OFFLINE'
-  | 'ONLINE'
-  | 'RINGING'
-  | 'CONNECTING'
-  | 'CONNECTED'
-  | 'BUSY';
+// Status
+export type { SignalStatus, ConnectionStatus } from './types/status';
 
-export interface Contact {
-  id: string;
-  name: string;
-  fingerprint: string;
-  status: ConnectionStatus;
-}
+// Events
+export { WsEvent } from './types/events';
+export type { WsEventType } from './types/events';
+
+// Payloads
+export type {
+  JackInPayload,
+  RingPayload,
+  PatchThroughPayload,
+  DisconnectPayload,
+  SignalPayload,
+  IncomingPayload,
+  HardlinePayload,
+  JackOutPayload,
+  PulsePayload,
+} from './types/payloads';
+
+// Contact
+export type { Contact } from './types/contact';

--- a/packages/shared/src/types/contact.ts
+++ b/packages/shared/src/types/contact.ts
@@ -1,0 +1,16 @@
+import type { ConnectionStatus } from './status';
+
+/**
+ * Contact stored locally on client.
+ * Server does not store contact lists.
+ */
+export interface Contact {
+  /** Local unique identifier */
+  id: string;
+  /** User-defined display name (editable) */
+  name: string;
+  /** Public identifier for P2P connection */
+  handle: string;
+  /** Current connection status */
+  status: ConnectionStatus;
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -1,0 +1,30 @@
+/**
+ * WebSocket event names for Operator communication.
+ */
+export const WsEvent = {
+  // Operative → Operator
+  /** Register connection with access code */
+  JACK_IN: 'jack_in',
+  /** Request call to target */
+  RING: 'ring',
+  /** Accept incoming call */
+  PATCH_THROUGH: 'patch_through',
+  /** Reject incoming call */
+  DISCONNECT: 'disconnect',
+
+  // Operator → Operative
+  /** Broadcast presence status update */
+  SIGNAL: 'signal',
+  /** Notify incoming call */
+  INCOMING: 'incoming',
+
+  // Bidirectional
+  /** WebRTC signaling (SDP/ICE) */
+  HARDLINE: 'hardline',
+  /** End call / disconnect session */
+  JACK_OUT: 'jack_out',
+  /** Heartbeat for connection keep-alive */
+  PULSE: 'pulse',
+} as const;
+
+export type WsEventType = (typeof WsEvent)[keyof typeof WsEvent];

--- a/packages/shared/src/types/payloads.ts
+++ b/packages/shared/src/types/payloads.ts
@@ -1,0 +1,61 @@
+import type { SignalStatus } from './status';
+
+// ============================================
+// Operative → Operator
+// ============================================
+
+/** Payload for jack_in event (register connection) */
+export interface JackInPayload {
+  access_code: string;
+  terminal_id: string;
+  handle: string;
+}
+
+/** Payload for ring event (request call) */
+export interface RingPayload {
+  target_handle: string;
+}
+
+/** Payload for patch_through event (accept call) */
+export interface PatchThroughPayload {
+  caller_handle: string;
+}
+
+/** Payload for disconnect event (reject call) */
+export interface DisconnectPayload {
+  caller_handle: string;
+}
+
+// ============================================
+// Operator → Operative
+// ============================================
+
+/** Payload for signal event (presence broadcast) */
+export interface SignalPayload {
+  handle: string;
+  status: SignalStatus;
+}
+
+/** Payload for incoming event (incoming call notification) */
+export interface IncomingPayload {
+  caller_handle: string;
+}
+
+// ============================================
+// Bidirectional
+// ============================================
+
+/** Payload for hardline event (WebRTC signaling) */
+export interface HardlinePayload {
+  target_handle: string;
+  /** SDP offer/answer or ICE candidate */
+  data: unknown;
+}
+
+/** Payload for jack_out event (end call) */
+export interface JackOutPayload {
+  target_handle: string;
+}
+
+/** Payload for pulse event (heartbeat) */
+export interface PulsePayload {}

--- a/packages/shared/src/types/status.ts
+++ b/packages/shared/src/types/status.ts
@@ -1,0 +1,17 @@
+/**
+ * Signal status for Operator's presence tracking.
+ * - JACKED_IN: Operative is connected and reachable
+ * - JACKED_OUT: Operative is disconnected
+ */
+export type SignalStatus = 'JACKED_IN' | 'JACKED_OUT';
+
+/**
+ * Full connection status for client-side state machine.
+ * Extends SignalStatus with call-related states.
+ */
+export type ConnectionStatus =
+  | 'JACKED_OUT'
+  | 'JACKED_IN'
+  | 'RINGING'
+  | 'CONNECTING'
+  | 'CONNECTED';


### PR DESCRIPTION
## Summary
- Shared 패키지에 thematic 용어 적용
- WebSocket 이벤트 상수 및 타입 정의
- 페이로드 인터페이스 추가

## Changes
- `SignalStatus`: `JACKED_IN`, `JACKED_OUT`
- `WsEvent`: `jack_in`, `signal`, `ring`, `incoming`, `patch_through`, `disconnect`, `hardline`, `jack_out`, `pulse`
- 모든 이벤트 페이로드 타입 정의
- `Contact` 인터페이스 업데이트 (`fingerprint` → `handle`)

## Test plan
- [x] `pnpm --filter @white-rabbit/shared build` 성공