### PR TITLE
feat: Phase 1.1 - 로컬 저장소 디렉토리 구조 및 권한 설정

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -6,13 +6,15 @@
     "dev": "tsx watch src/index.tsx",
     "build": "tsup src/index.tsx --format cjs --dts",
     "start": "node dist/index.js",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test:init": "tsx src/storage/test-init.ts"
   },
   "dependencies": {
     "ink": "^5.0.0",
     "react": "^18.2.0"
   },
   "devDependencies": {
+    "@types/node": "^20.0.0",
     "@types/react": "^18.2.0",
     "tsup": "^8.0.0",
     "tsx": "^4.7.0",

--- a/apps/client/src/storage/init.ts
+++ b/apps/client/src/storage/init.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { WHITE_RABBIT_DIR, KEYS_DIR, PATHS } from './paths.js';
+
+/**
+ * White Rabbit 로컬 저장소 초기화
+ * 
+ * 디렉토리 생성 및 권한 설정을 수행합니다.
+ */
+
+/**
+ * 디렉토리 존재 여부 확인
+ */
+export function directoryExists(dirPath: string): boolean {
+  try {
+    const stats = fs.statSync(dirPath);
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 파일 존재 여부 확인
+ */
+export function fileExists(filePath: string): boolean {
+  try {
+    const stats = fs.statSync(filePath);
+    return stats.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 디렉토리 생성 (권한 설정 포함)
+ * 
+ * @param dirPath - 생성할 디렉토리 경로
+ * @param mode - 파일 권한 (기본값: 0o700 = rwx------)
+ */
+export function createDirectory(dirPath: string, mode: number = 0o700): void {
+  if (directoryExists(dirPath)) {
+    return;
+  }
+
+  try {
+    fs.mkdirSync(dirPath, {
+      recursive: true, // 부모 디렉토리도 자동 생성
+      mode,            // chmod 700: 소유자만 접근 가능
+    });
+    console.log(`✓ Created directory: ${dirPath} (mode: ${mode.toString(8)})`);
+  } catch (error) {
+    throw new Error(
+      `Failed to create directory ${dirPath}: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+/**
+ * White Rabbit 루트 디렉토리 초기화
+ * 
+ * ~/.whiterabbit/ 디렉토리를 생성합니다.
+ * 권한: 0o700 (rwx------) - 소유자만 읽기/쓰기/실행 가능
+ */
+export function initializeRootDirectory(): void {
+  console.log('Initializing White Rabbit directory...');
+  createDirectory(WHITE_RABBIT_DIR, 0o700);
+}
+
+/**
+ * 키 디렉토리 초기화
+ * 
+ * ~/.whiterabbit/keys/ 디렉토리를 생성합니다.
+ * 권한: 0o700 (rwx------) - 개인키 보호를 위해 더욱 엄격
+ */
+export function initializeKeysDirectory(): void {
+  console.log('Initializing keys directory...');
+  createDirectory(KEYS_DIR, 0o700);
+}
+
+/**
+ * 모든 디렉토리 초기화
+ * 
+ * White Rabbit에 필요한 모든 디렉토리를 생성합니다.
+ * 이미 존재하는 경우 스킵됩니다.
+ */
+export function initializeDirectories(): void {
+  console.log('🐰 Initializing White Rabbit storage...\n');
+
+  // 1. 루트 디렉토리
+  initializeRootDirectory();
+
+  // 2. 키 디렉토리
+  initializeKeysDirectory();
+
+  console.log('\n✓ Storage initialized successfully!');
+}
+
+/**
+ * 저장소 상태 확인
+ * 
+ * 필요한 디렉토리와 파일이 존재하는지 확인합니다.
+ */
+export interface StorageStatus {
+  initialized: boolean;
+  rootExists: boolean;
+  keysDir: boolean;
+  configExists: boolean;
+  contactsDbExists: boolean;
+  privateKeyExists: boolean;
+  publicKeyExists: boolean;
+}
+
+export function checkStorageStatus(): StorageStatus {
+  return {
+    initialized: directoryExists(WHITE_RABBIT_DIR) && directoryExists(KEYS_DIR),
+    rootExists: directoryExists(WHITE_RABBIT_DIR),
+    keysDir: directoryExists(KEYS_DIR),
+    configExists: fileExists(PATHS.config),
+    contactsDbExists: fileExists(PATHS.contacts),
+    privateKeyExists: fileExists(PATHS.privateKey),
+    publicKeyExists: fileExists(PATHS.publicKey),
+  };
+}
+
+/**
+ * 저장소 초기화 여부 확인
+ * 
+ * @returns 저장소가 초기화되었으면 true
+ */
+export function isStorageInitialized(): boolean {
+  const status = checkStorageStatus();
+  return status.initialized;
+}
+
+/**
+ * 저장소 상태 출력 (디버깅용)
+ */
+export function printStorageStatus(): void {
+  const status = checkStorageStatus();
+
+  console.log('📦 Storage Status:\n');
+  console.log(`  Root directory:    ${status.rootExists ? '✓' : '✗'} ${PATHS.root}`);
+  console.log(`  Keys directory:    ${status.keysDir ? '✓' : '✗'} ${PATHS.keysDir}`);
+  console.log(`  Config file:       ${status.configExists ? '✓' : '✗'} ${PATHS.config}`);
+  console.log(`  Contacts DB:       ${status.contactsDbExists ? '✓' : '✗'} ${PATHS.contacts}`);
+  console.log(`  Private key:       ${status.privateKeyExists ? '✓' : '✗'} ${PATHS.privateKey}`);
+  console.log(`  Public key:        ${status.publicKeyExists ? '✓' : '✗'} ${PATHS.publicKey}`);
+  console.log(`\n  Initialized:       ${status.initialized ? '✓ Yes' : '✗ No'}`);
+}

--- a/apps/client/src/storage/paths.ts
+++ b/apps/client/src/storage/paths.ts
@@ -1,0 +1,66 @@
+import path from 'node:path';
+import os from 'node:os';
+
+/**
+ * White Rabbit 로컬 저장소 경로 상수
+ * 
+ * 모든 데이터는 ~/.whiterabbit/ 디렉토리에 저장됩니다.
+ * - 연락처 (contacts.db)
+ * - 설정 파일 (config.json)
+ * - 암호화 키 (keys/)
+ */
+
+// 홈 디렉토리 기반 경로 생성 헬퍼
+function getHomePath(...segments: string[]): string {
+    return path.join(os.homedir(), '.whiterabbit', ...segments);
+}
+
+/**
+ * 루트 디렉토리: ~/.whiterabbit/
+ * 모든 White Rabbit 데이터의 루트
+ */
+export const WHITE_RABBIT_DIR = getHomePath();
+
+/**
+ * 설정 파일: ~/.whiterabbit/config.json
+ * 사용자 이름, Access Code, Operator URL 등 저장
+ */
+export const CONFIG_FILE = getHomePath('config.json');
+
+/**
+ * 연락처 데이터베이스: ~/.whiterabbit/contacts.db
+ * SQLite 데이터베이스로 연락처 목록 저장
+ */
+export const CONTACTS_DB = getHomePath('contacts.db');
+
+/**
+ * 키 디렉토리: ~/.whiterabbit/keys/
+ * Ed25519 키 쌍 저장 (개인키, 공개키)
+ */
+export const KEYS_DIR = getHomePath('keys');
+
+/**
+ * 개인키: ~/.whiterabbit/keys/terminal.key
+ * Ed25519 개인키 (chmod 600 필수)
+ * ⚠️ 절대 외부로 전송하지 않음!
+ */
+export const PRIVATE_KEY = getHomePath('keys', 'terminal.key');
+
+/**
+ * 공개키: ~/.whiterabbit/keys/terminal.pub
+ * Ed25519 공개키 (Terminal ID의 기반)
+ * Operator에 공유됨
+ */
+export const PUBLIC_KEY = getHomePath('keys', 'terminal.pub');
+
+/**
+ * 경로 목록 (초기화 및 검증용)
+ */
+export const PATHS = {
+    root: WHITE_RABBIT_DIR,
+    config: CONFIG_FILE,
+    contacts: CONTACTS_DB,
+    keysDir: KEYS_DIR,
+    privateKey: PRIVATE_KEY,
+    publicKey: PUBLIC_KEY,
+} as const;

--- a/apps/client/src/storage/test-init.ts
+++ b/apps/client/src/storage/test-init.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+/**
+ * Storage 초기화 테스트 스크립트
+ * 
+ * 실행: node --loader ts-node/esm src/storage/test-init.ts
+ * 또는: tsx src/storage/test-init.ts
+ */
+
+import {
+    initializeDirectories,
+    printStorageStatus,
+    checkStorageStatus,
+} from './init.js';
+
+async function main() {
+    console.log('🐰 White Rabbit Storage Initialization Test\n');
+    console.log('='.repeat(50));
+    console.log();
+
+    // 1. 초기 상태 확인
+    console.log('📊 Current Status (BEFORE initialization):\n');
+    printStorageStatus();
+    console.log();
+    console.log('='.repeat(50));
+    console.log();
+
+    // 2. 디렉토리 초기화
+    try {
+        initializeDirectories();
+    } catch (error) {
+        console.error('❌ Initialization failed:', error);
+        process.exit(1);
+    }
+
+    console.log();
+    console.log('='.repeat(50));
+    console.log();
+
+    // 3. 초기화 후 상태 확인
+    console.log('📊 Status (AFTER initialization):\n');
+    printStorageStatus();
+
+    // 4. 결과 확인
+    const status = checkStorageStatus();
+    console.log();
+    console.log('='.repeat(50));
+
+    if (status.initialized) {
+        console.log('\n✅ All directories initialized successfully!');
+        console.log('\n💡 Next steps:');
+        console.log('   1. Generate Ed25519 keys (Phase 1.2)');
+        console.log('   2. Create config.json (Phase 1.3)');
+        console.log('   3. Initialize contacts.db (Phase 1.4)');
+    } else {
+        console.log('\n❌ Initialization incomplete!');
+        process.exit(1);
+    }
+}
+
+main().catch((error) => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1
     devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.30
       '@types/react':
         specifier: ^18.2.0
         version: 18.3.27
@@ -547,6 +550,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@20.19.30':
+    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
 
   '@types/node@25.0.10':
     resolution: {integrity: sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==}
@@ -1330,6 +1336,9 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -1685,6 +1694,10 @@ snapshots:
   '@tsconfig/node16@1.0.4': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/node@20.19.30':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@25.0.10':
     dependencies:
@@ -2516,6 +2529,8 @@ snapshots:
       '@lukeed/csprng': 1.1.0
 
   uint8array-extras@1.5.0: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 


### PR DESCRIPTION
# Phase 1.1: 로컬 저장소 디렉토리 구조 및 권한 설정

## 📋 작업 내용

White Rabbit Operative 클라이언트의 로컬 저장소 기반을 구축했습니다.

### 구현된 기능

#### 1. 경로 관리 시스템 (`paths.ts`)
- `~/.whiterabbit/` 기반 경로 상수 정의
- OS 독립적인 경로 생성 (macOS, Linux, Windows 지원)
- 중앙 집중식 경로 관리

```typescript
export const WHITE_RABBIT_DIR = '~/.whiterabbit/';
export const CONFIG_FILE = '~/.whiterabbit/config.json';
export const CONTACTS_DB = '~/.whiterabbit/contacts.db';
export const KEYS_DIR = '~/.whiterabbit/keys/';
export const PRIVATE_KEY = '~/.whiterabbit/keys/terminal.key';
export const PUBLIC_KEY = '~/.whiterabbit/keys/terminal.pub';
```

#### 2. 디렉토리 초기화 시스템 (`init.ts`)
- 필요한 디렉토리 자동 생성
- **파일 권한 설정** (chmod 700)
- 저장소 상태 확인 및 검증
- 안전한 재실행 (이미 존재하면 스킵)

주요 함수:
- `initializeDirectories()`: 모든 디렉토리 생성
- `checkStorageStatus()`: 저장소 상태 확인
- `isStorageInitialized()`: 초기화 여부 확인
- `printStorageStatus()`: 디버깅용 상태 출력

#### 3. 테스트 스크립트 (`test-init.ts`)
- 초기화 동작 검증
- Before/After 상태 비교
- 개발 중 디버깅 지원

실행: `pnpm test:init`

---

## 🔐 파일 권한 설정 (File Permissions)

### 왜 필요한가?

White Rabbit는 **Privacy First** 원칙을 따릅니다. 로컬에 저장되는 데이터는:
- Ed25519 개인키 (Terminal ID의 기반)
- Access Code (라이선스)
- 연락처 정보

이러한 민감한 정보가 **같은 컴퓨터를 사용하는 다른 사용자에게 노출되어서는 안 됩니다.**

### Unix 파일 권한 시스템

Unix/Linux/macOS는 각 파일과 디렉토리에 권한 정보를 저장합니다.

#### 권한 구조
```
-rwxr-xr-x
 ||||||||| 
 |||++++++-- Others (다른 사용자들)
 |||
 +++-------- Group (그룹)
 |
 +---------- Owner (소유자)

r = read (4)
w = write (2)
x = execute (1)
```

#### 숫자 표기법
```
chmod 700 = rwx------
  7 = 4+2+1 (소유자: 읽기+쓰기+실행)
  0 = 없음   (그룹: 권한 없음)
  0 = 없음   (다른 사람: 권한 없음)

chmod 755 = rwxr-xr-x
  7 = rwx (소유자: 모든 권한)
  5 = r-x (그룹: 읽기+실행)
  5 = r-x (다른 사람: 읽기+실행)

chmod 600 = rw-------
  6 = 4+2 (소유자: 읽기+쓰기)
  0 = --- (그룹: 권한 없음)
  0 = --- (다른 사람: 권한 없음)
```

### 레이어 구조 이해하기

```
┌─────────────────────────────────────────┐
│  우리 코드 (TypeScript/JavaScript)       │
│  fs.mkdirSync(path, { mode: 0o700 })   │
└────────────────┬────────────────────────┘
                 │
┌────────────────▼────────────────────────┐
│  Node.js fs 모듈 (JavaScript)           │
│  내장 모듈, OS API 래핑                  │
└────────────────┬────────────────────────┘
                 │
┌────────────────▼────────────────────────┐
│  Node.js C++ Bindings                   │
│  libuv + 시스템 콜 래핑                  │
└────────────────┬────────────────────────┘
                 │
┌────────────────▼────────────────────────┐
│  OS System Calls (Kernel)               │
│  macOS: open(), chmod()                 │
│  Linux: open(), chmod()                 │
│  Windows: CreateFile(), SetFileSecurity │
└────────────────┬────────────────────────┘
                 │
┌────────────────▼────────────────────────┐
│  File System (디스크)                    │
│  inode에 메타데이터 저장                 │
└─────────────────────────────────────────┘
```

### 구현 방법

Node.js는 OS의 시스템 콜을 JavaScript로 사용할 수 있게 추상화합니다.

```typescript
// 8진수(octal) 표기법 사용
fs.mkdirSync(dirPath, {
  recursive: true,  // 부모 디렉토리도 자동 생성
  mode: 0o700,      // chmod 700 = rwx------
});
```

#### 실행 플로우

```typescript
// 1. JavaScript 코드
createDirectory('/Users/jay/.whiterabbit/keys', 0o700);

// 2. Node.js fs 모듈 (JavaScript)
fs.mkdirSync(path, { mode: 0o700 });

// 3. Node.js C++ 바인딩
binding.mkdir(path, 0o700);

// 4. libuv (비동기 I/O 라이브러리)
uv_fs_mkdir(path, 0o700);

// 5. OS 시스템 콜 (macOS)
mkdir("/Users/jay/.whiterabbit/keys", 0700);

// 6. 커널
// - 디렉토리 생성
// - inode 할당
// - 권한 0700 설정
// - uid=501 (jay) 설정
// - 디스크에 메타데이터 기록
```

### 검증

생성된 디렉토리의 권한 확인:

```bash
$ ls -la ~/.whiterabbit/
drwx------  3 jay  staff   96 Feb  1 14:22 .whiterabbit
drwx------  2 jay  staff   64 Feb  1 14:22 keys
```

- `drwx------` = 700 권한 ✅
- 소유자(jay)만 접근 가능
- 그룹과 다른 사용자는 접근 불가

### 왜 중요한가?

#### 시나리오 1: 공유 개발 서버
```bash
# 여러 개발자가 같은 서버 사용
$ whoami
jay

# 권한 설정 O (안전)
$ ls -la ~/.whiterabbit/keys/terminal.key
-rw-------  1 jay  staff  64 Feb 1 10:00 terminal.key
# → 다른 개발자가 접근 불가 ✅

# 권한 설정 X (위험)
-rw-r--r--  1 jay  staff  64 Feb 1 10:00 terminal.key
# → 다른 개발자도 읽을 수 있음 🚨
```

#### 시나리오 2: 가족 공용 컴퓨터
```bash
# 부모님과 같은 Mac 사용
$ ls -la ~/.whiterabbit/
drwx------  3 jay  staff  96 Feb 1 10:00 .whiterabbit
# → 부모님이 실수로도 접근 불가 ✅

# 권한 설정 X
drwxr-xr-x  3 jay  staff  96 Feb 1 10:00 .whiterabbit
# → 부모님이 ls ~/.whiterabbit/ 가능 🚨
```

### 참고: SSH도 동일한 방식

GitHub SSH 키도 같은 원리입니다:

```bash
$ ls -la ~/.ssh/id_rsa
-rw-------  1 jay  staff  3389 Jan 1 10:00 id_rsa
```

SSH는 개인키 권한이 느슨하면 아예 실행을 거부합니다:

```bash
$ chmod 644 ~/.ssh/id_rsa
$ ssh git@github.com
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@  WARNING: UNPROTECTED PRIVATE KEY FILE! @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0644 are too open.
This private key will be ignored.
```

---

## 📁 생성된 디렉토리 구조

```
~/.whiterabbit/
  ├── (config.json)          # Phase 1.3에서 생성 예정
  ├── (contacts.db)          # Phase 1.4에서 생성 예정
  └── keys/
      ├── (terminal.key)     # Phase 1.2에서 생성 예정 (chmod 600)
      └── (terminal.pub)     # Phase 1.2에서 생성 예정
```

---

## 🧪 테스트

### 실행 방법

```bash
pnpm test:init
```

### 결과

```
📦 Storage Status:

  Root directory:    ✓ /Users/jaylee/.whiterabbit
  Keys directory:    ✓ /Users/jaylee/.whiterabbit/keys
  Config file:       ✗ /Users/jaylee/.whiterabbit/config.json
  Contacts DB:       ✗ /Users/jaylee/.whiterabbit/contacts.db
  Private key:       ✗ /Users/jaylee/.whiterabbit/keys/terminal.key
  Public key:        ✗ /Users/jaylee/.whiterabbit/keys/terminal.pub

  Initialized:       ✓ Yes
```

### 권한 확인

```bash
$ ls -la ~/.whiterabbit/
drwx------  3 jaylee  staff   96 Feb  1 14:22 .
drwxr-x---+ 51 jaylee  staff  1632 Feb  1 14:22 ..
drwx------  2 jaylee  staff   64 Feb  1 14:22 keys
```

✅ 모든 디렉토리가 `700` 권한으로 생성됨

---

## 📦 변경 사항

### 새로운 파일
- `apps/client/src/storage/paths.ts`: 경로 상수
- `apps/client/src/storage/init.ts`: 초기화 로직
- `apps/client/src/storage/test-init.ts`: 테스트 스크립트

### 수정된 파일
- `apps/client/package.json`: 
  - `@types/node` 추가
  - `test:init` 스크립트 추가

---

## 🚀 다음 단계

- [ ] Phase 1.2: Ed25519 키 생성
- [ ] Phase 1.3: 설정 파일 관리
- [ ] Phase 1.4: 연락처 데이터베이스

---

## 🔍 참고 자료

- [Node.js fs.mkdirSync](https://nodejs.org/api/fs.html#fsmkdirsyncpath-options)
- [Unix File Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation)
- [chmod man page](https://man7.org/linux/man-pages/man1/chmod.1.html)
